### PR TITLE
MIT is a university not a license 

### DIFF
--- a/wwwroot/docfx.json
+++ b/wwwroot/docfx.json
@@ -29,7 +29,7 @@
       "_enableSearch": true,
       "_appLogoPath": "images/Icon-Transparent-1024.png",
       "_appFaviconPath": "images/icon.ico",
-      "_appFooter": "<footer id=\"copyright\">(c) TKMM-Team and Contributors. MIT.</footer>",
+      "_appFooter": "<footer id=\"copyright\">(c) TKMM-Team and Contributors under the MIT License</footer>",
       "pdf": true
     },
     "postProcessors": [


### PR DESCRIPTION
Change the copyright footer to refer to MIT license instead of MIT because MIT is a university 🙂 