### PR TITLE
Change navbar icons to brand guideline appropriate colours

### DIFF
--- a/wwwroot/templates/custom/public/main.css
+++ b/wwwroot/templates/custom/public/main.css
@@ -199,3 +199,8 @@ video {
         color: var(--alert-important-color);
     }
 }
+
+.navbar #navbar form.icons > a[title="Discord"],
+.navbar #navbar form.icons > a[title="GitHub"] {
+    color: #ffffff;
+}

--- a/wwwroot/templates/custom/public/main.css
+++ b/wwwroot/templates/custom/public/main.css
@@ -10,6 +10,7 @@
     --code-background: #c7c7c7;
     --bs-code-color: #333537;
     --bs-border-radius: 0.2rem;
+    --brand-foreground-color: #000000;
     --alert-tip-color: #49e463;
     --alert-info-color: #386ec0;
     --alert-warn-color: #ed7741;
@@ -22,6 +23,7 @@
     --bs-body-bg-rgb: 48, 54, 61;
     --bs-code-color: #d1d9e1;
     --code-background: #434343;
+    --brand-foreground-color: #FFFFFF;
 }
 
 a {
@@ -202,5 +204,5 @@ video {
 
 .navbar #navbar form.icons > a[title="Discord"],
 .navbar #navbar form.icons > a[title="GitHub"] {
-    color: #ffffff;
+    color: var(--brand-foreground-color);
 }


### PR DESCRIPTION
## Changes

<!-- Please summarize your changes. -->
Changed the Discord and GitHub navbar icons to the colour #ffffff in dark mode, and #000000 in light mode to match the brand guidelines of both brands.

![image](https://github.com/user-attachments/assets/412daeb5-b0a3-49d6-a624-fc3f18d7a5a5)
![image](https://github.com/user-attachments/assets/0871e67a-d826-42d9-818c-258c147eac93)

<!-- Please link to any applicable information (forum posts, bug reports, etc.). -->

## Checks

By submitting your pull request for review, you agree to the following:

- [ ] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [ ] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [ ] To the best of my knowledge, all proposed changes are accurate.